### PR TITLE
webdav utilities

### DIFF
--- a/examples/example_pwf.json
+++ b/examples/example_pwf.json
@@ -1,0 +1,6 @@
+#this file should have setttings chmod 600
+
+{
+"webdav_login":"user",
+"webdav_password":"password"
+}

--- a/examples/example_webdav_option_file.json
+++ b/examples/example_webdav_option_file.json
@@ -1,0 +1,4 @@
+{
+"webdav_hostname":"https://webdav.grid.surfsara.nl:2880/pnfs/grid.sara.nl/data/projects.nl/eecolidar/",
+"authenticationfile":"/Users/eslt0101/Projects/REPOS/eScience/eEcoLiDAR/lcMacroPipeline/testdata/webdavclienttest/example_pwf.json"
+}

--- a/lc_macro_pipeline/remote_utils.py
+++ b/lc_macro_pipeline/remote_utils.py
@@ -5,7 +5,7 @@ behaviour of Client.list() method no use is made of higher level methods (push,
 pull) provided.
 """
 
-import pathlib
+#import pathlib
 import os
 import shutil
 from webdav3.client import Client as wd3client
@@ -198,6 +198,10 @@ def pull_directory_from_remote(wdclient,local_dir,remote_dir):
         raise
 
     records = wdclient.list(remote_dir)
+    """
+    list method returns directory queried as first argument when querying
+    webdav API to SURFsara dCache. This implementation accounts for that.
+    """
     records=records[1:]
 
     os.makedirs(local_dir)

--- a/lc_macro_pipeline/remote_utils.py
+++ b/lc_macro_pipeline/remote_utils.py
@@ -1,0 +1,176 @@
+#remote_utils.py
+
+import pathlib
+import os
+import json
+from webdav3.client import Client as wd3client
+from webdav3.client import WebDavException
+from lc_macro_pipeline.utils import check_path_exists, check_file_exists, \
+    check_dir_exists, get_args_from_configfile, shell_execute_command
+
+def get_wdclient(options=None):
+    """
+     get webdav
+
+     :param options: specification of options for the client. Either as
+                     path to configuration file (str) or a dict
+    """
+    if isinstance(options,str):
+        check_file_exists(options,should_exist=True)
+        options = get_options_from_file(options)
+    else if isinstance(options,dict):
+        pass
+    else:
+        raise TypeError('unrecognized type {} for client \
+                         options'.format(type(options)))
+    #check_options(options)
+    wdclient = wd3client(options)
+    return wdclient
+
+
+def get_options_from_file(options):
+    """
+    read webdav client option from configuation file. Expects presence of
+    an authentication file with user/pwd details
+
+    :param options: filepath of configuration file
+    """
+    args = get_args_from_configfile(options)
+    if 'authenticationfile' in args.keys():
+        check_file_exists(args['authenticationfile'],should_exist=True)
+        authentication = get_args_from_configfile(args['authenticationfile'])
+        args.pop('authenticationfile',None)
+        args.update(authentication)
+    return args
+
+
+def check_options(options):
+    #TODO add sanity check of options
+    return
+
+
+def pull_file_from_remote(wdclient,remote_origin,local_destination,file):
+    """
+    download a file from remote store to local fs.
+
+    :param wdclient: instance of webdav client
+    :param remote_origin: parent directory path on remote fs
+    :param local_destination: parent directory path on local fs
+    :param file: name of file to be downloaded
+    """
+    if not isinstance(file,str):
+        print('Expected type str but received type {}'.format(type(file)))
+        raise TypeError
+
+    remote_path_to_file = os.path.join(remote_origin,file)
+    local_path_to_file = oss.path.join(local_destination,file)
+
+    if wdclient.check(remote_path_to_file) == True:
+        try:
+            wdclient.download_sync(remote_path_to_file,local_path_to_file)
+        except WebDavException as exception:
+            print('Failed to retrieve {} from \
+                                            remote origin'.format(file))
+            raise
+    else:
+        print("remote record {} does not exist on remote host".format(remote_path_to_file))
+        raise RemoteResourceNotFound(remote_path_to_file)
+
+
+def push_file_to_remote(wdclient,local_origin,remote_destination,file):
+    """
+    upload file to remote
+
+    :param wdclient: instance of webdav client
+    :param local_origin: directory of file on local fs
+    :param remote_destination: target directory of file on remote fs
+    :param file: file name
+    """
+    if not isinstance(file,str):
+        print('Expected type str but received type {}'.format(type(file)))
+        raise TypeError
+
+    remote_path_to_file = os.path.join(remote_destination,file)
+    local_path_to_file = oss.path.join(local_origin,file)
+
+    if wdclient.check(remote_destination) == True:
+        try:
+            wdclient.upload_sync(remote_path_to_file,local_path_to_file)
+        except WebDavException as exception:
+            print('Failed to upload {} to \
+                                            remote destination'.format(file))
+            raise
+    else:
+        print("remote parent directory {} does not exist ".format(remote_destination))
+        raise RemoteResourceNotFound(remote_path_to_file)
+
+
+def pull_directory_from_remote(wdclient,local_dir,remote_dir,mode='pull'):
+    """
+    pull directory from remote to local fs. This can be done as a full download
+    or a (one-way) sync.
+
+    :param wdclient: instance of webdav client
+    :param local_dir: local directory to be synced or created
+    :param remote_dir: remote directory to be pulled or downloaded
+    :param mode: 'pull': sync directory ; 'download': download
+    """
+    if mode == 'pull':
+        try:
+            wdclient.pull(remote_directory=remote_dir,local_directory=local_dir)
+        except WebDavException as exception:
+            print('Failed to pull {} to \
+                                    {}'.format(remote_dir,local_dir))
+            raise
+
+    else if mode == 'download'
+        try:
+            wdclient.download_sync(remote_dir,local_dir)
+        except WebDavException as exception:
+            print('Failed to download {} to \
+                                    {}'.format(remote_dir,local_dir))
+            raise
+
+
+def push_directory_to_remote(wdclient,local_dir,remote_dir,mode='push'):
+    """
+    push directory from local fs to remote. This can be done as a full upload
+    or a (one-way) sync.
+
+    :param wdclient: instance of webdav client
+    :param local_dir: local directory to be synced or uploaded
+    :param remote_dir: remote directory to be synced or uploaded
+    :param mode: 'push': sync directory ; 'upload': upload
+    """
+    if not os.path.isdir(local_dir):
+        print('{} is not a directory'.format(local_dir))
+        raise NotADirectoryError(local_dir)
+
+    if mode == 'push':
+        try:
+            wdclient.push(remote_directory=remote_dir,local_directory=local_dir)
+        except WebDavException as exception:
+            print('Failed to push {} to \
+                                    {}'.format(local_dir,remote_dir))
+            raise
+
+    else if mode == 'upload':
+        try:
+            wdclient.upload_sync(local_dir,remote_dir)
+        except WebDavException as exception:
+            print('Failed to upload {} to \
+                                    {}'.format(local_dir,remote_dir))
+            raise
+
+
+def purge_local(local_record):
+    """
+    remove record from local file system
+
+    :param local_record : full path of local_record
+    """
+    if not os.path.exists(local_record):
+        print('local record {} does not exits'.format(local_record))
+        raise FileNotFoundError(local_record)
+
+    shell_execute_command('rm -r '+local_record)

--- a/lc_macro_pipeline/retiler.py
+++ b/lc_macro_pipeline/retiler.py
@@ -8,14 +8,17 @@ import json
 from lc_macro_pipeline.pipeline import Pipeline
 from lc_macro_pipeline.utils import shell_execute_cmd, check_file_exists, \
     check_dir_exists
+from lc_macro_pipeline.remote_utils import get_wdclient, pull_file_from_remote, \
+    push_directory_to_remote, purge_local
 
 
 class Retiler(Pipeline):
     """ Split point cloud data into smaller tiles on a regular grid. """
 
     def __init__(self):
-        self.pipeline = ('localfs', 'tiling', 'split_and_redistribute',
-                         'validate')
+        self.pipeline = ('localfs', 'pullremote', 'tiling',
+                         'split_and_redistribute', 'validate',
+                         'pushremote', 'cleanlocalfs')
         self.temp_folder = None
         self.filename = None
         self.tiled_temp_folder = None
@@ -48,6 +51,37 @@ class Retiler(Pipeline):
             self.tiled_temp_folder.mkdir(parents=True)
         return self
 
+    def pullremote(self, options, remote_origin):
+        """
+        pull file from remote to local fs
+
+        :param options: setup options for webdav client. Can be a filepath
+        :param remote_origin: path to parent directory of file on remote fs
+        """
+        p=self.filename
+        wdclient = get_wdclient(options)
+        pull_file_from_remote(wdclient,remote_origin,p.parent.as_posix(),p.name)
+        return self
+
+    def pushremote(self, options, remote_destination):
+        """
+        push retiled directories to remote and cleaan up local fs
+
+        :param options: setup options for webdav
+        :param remote_destination: remote directory to push to
+        """
+        wdclient = get_wdclient(options)
+        push_directory_to_remote(wdclient, self.tiled_temp_folder.as_posix(), remote_destination)
+        return self
+
+    def cleanlocalfs(self):
+        """
+        remove pulled input file and results of tiling (after push)
+        """
+        purge_local(self.filename.as_posix())
+        purge_local(self.temp_tiled_folder.as_posix())
+        return self
+
     def tiling(self, min_x, min_y, max_x, max_y, n_tiles_side):
         """
         Setup the grid to which the input file is retiled.
@@ -58,7 +92,7 @@ class Retiler(Pipeline):
         :param max_y: max y value of tiling schema
         :param n_tiles_side: number of tiles along axis. Tiling MUST be square
         (enforced)
-        """
+        """wdclient = get_wdclient(options)
         self.tiling_mins[:] = [min_x, min_y]
         self.tiling_maxs[:] = [max_x, max_y]
         self.n_tiles_side = n_tiles_side

--- a/lc_macro_pipeline/retiler.py
+++ b/lc_macro_pipeline/retiler.py
@@ -92,7 +92,7 @@ class Retiler(Pipeline):
         :param max_y: max y value of tiling schema
         :param n_tiles_side: number of tiles along axis. Tiling MUST be square
         (enforced)
-        """wdclient = get_wdclient(options)
+        """
         self.tiling_mins[:] = [min_x, min_y]
         self.tiling_maxs[:] = [max_x, max_y]
         self.n_tiles_side = n_tiles_side

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ lazperf
 numpy
 pylas
 laserchicken @ git+git://github.com/eEcoLiDAR/laserchicken@feature_extra_io_tools#egg=laserchicken
+shutil
+webdavclient3


### PR DESCRIPTION
remote_utils module to support data exchange with webdav. 

Is currently aimed at SURF's WebDav dCache interface. These is an issue in how the webdav3 client parses the response of its list() method provided by the dCache/WebDav server, so that the remote_utils currently deal explicitly with the known behaviour.

Suggestion made for how to bind these methods into a pipeline using the retiler.py pipeline.

If deemed acceptable this can be implemented for the others as well.

Remaining issues:
passing options for client setup (currently via a setup file) and authentication (username/password in a authentication file for now, possibly with tokens soon.

Please review. Could be merged, but maybe better to discuss improve on the above and then merge